### PR TITLE
feat(notion-sync): migrate @lacolaco/notion-sync from v7 to v8

### DIFF
--- a/.claude/skills/notion-sync-migration/SKILL.md
+++ b/.claude/skills/notion-sync-migration/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: notion-sync-migration
+description: "@lacolaco/notion-syncのメジャーバージョンアップを実行する。notion-syncのアップグレード、マイグレーション、バージョンアップと言われた時に使用する。新バージョンが未公開の場合はポーリングで待機する。"
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash(pnpm add:*)
+  - Bash(pnpm format:*)
+  - Bash(pnpm notion-sync:*)
+  - Bash(npx tsc:*)
+  - Bash(npm view:*)
+  - Bash(git:*)
+  - Bash(gh:*)
+  - Bash(sleep:*)
+---
+
+# notion-sync Migration
+
+`@lacolaco/notion-sync`のメジャーバージョンアップを安全に実行する。
+
+## 原則
+
+**旧バージョンの知識を全て捨てろ。** 新バージョンのCHANGELOGとREADMEを全文読むまで、コード変更を一切行うな。
+
+## 手順
+
+### 1. 現状確認
+
+```bash
+grep "notion-sync" package.json
+```
+
+現在のバージョンと、対象バージョンを特定する。
+
+### 2. 新バージョンの取得
+
+対象バージョンがnpmに公開済みか確認する。
+
+```bash
+npm view @lacolaco/notion-sync version
+```
+
+未公開の場合、バックグラウンドで30秒間隔でポーリングする。
+
+```bash
+while true; do
+  version=$(npm view @lacolaco/notion-sync version 2>/dev/null)
+  if [[ "$version" == <target-major>.* ]]; then
+    echo "published: $version"
+    break
+  fi
+  sleep 30
+done
+```
+
+### 3. インストール
+
+```bash
+pnpm add -D @lacolaco/notion-sync@<version>
+```
+
+### 4. ドキュメント精読（省略禁止）
+
+インストール後、以下を**全文Read**する。grepでの部分検索は精読の代替にならない。
+
+1. `node_modules/@lacolaco/notion-sync/CHANGELOG.md` — Breaking Changesを全て把握
+2. `node_modules/@lacolaco/notion-sync/README.md` — 新APIの仕様とMigration Guideを把握
+
+Breaking Changesの一覧を列挙し、現在のコード（`tools/notion-sync/main.ts`）への影響を対応付けてからコード変更に着手する。
+
+### 5. コード変更
+
+`tools/notion-sync/main.ts`を修正する。
+
+変更時の注意:
+- Migration Guideの Before/After に従う
+- 型パラメータの追加など、Breaking Change以外の改善も適用する
+- 不要になった型アサーション（`as`キャスト）は削除する
+
+### 6. 検証
+
+以下を全て通過させる。
+
+```bash
+npx tsc --noEmit -p tools/tsconfig.json
+pnpm notion-sync -- --dry-run
+pnpm format
+```
+
+dry-runの出力を確認し、queryFilterやmetadata生成が正しく動作していることを検証する。
+
+### 7. コミット・PR
+
+通常のpr-lifecycleスキルに従う。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,10 @@ Options:
 - Prettier is configured in `.prettierrc.json` (single quotes, trailing commas, 80 char width)
 - Articles are written in Markdown and must include Zenn frontmatter (title, emoji, type, topics, published)
 
+## Dependency Investigation
+
+npmパッケージの情報（CHANGELOG、README、API）を調べるとき、`node_modules` 内のファイルを直接Readする。`npm view` やWeb検索はインストール前・未公開時のフォールバック。
+
 ## Development Guidelines
 
 ### Impact Scope Pre-verification

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@lacolaco/notion-sync": "^7.0.0",
+    "@lacolaco/notion-sync": "^8.0.0",
     "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.18.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.34.4
     devDependencies:
       '@lacolaco/notion-sync':
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^8.0.0
+        version: 8.0.0
       '@notionhq/client':
         specifier: 3.1.3
         version: 3.1.3
@@ -327,8 +327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lacolaco/notion-sync@7.0.0':
-    resolution: {integrity: sha512-7+WY6Iv64p0bjyxOjIkfpwwWDQeOrVI/eEj4omt35sY084lO1+Nhjx+yJEBw+V2D67+Z1NxC8L3K2BcLgQIzUg==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/7.0.0/351f8d49fef323cfe1b404f4f67f0d642058efc3}
+  '@lacolaco/notion-sync@8.0.0':
+    resolution: {integrity: sha512-PIxmKUnTPJtPFkKWk07NtWoVtwoa94thOL9vFuP9wIHOAFY9Eu/v0i5phjFcT2pYQmioj/qwxF8CE335xwvx4w==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/8.0.0/ac1743e59369e6aab6e57cf28b3441a48b376495}
 
   '@notionhq/client@3.1.3':
     resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
@@ -644,7 +644,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@lacolaco/notion-sync@7.0.0':
+  '@lacolaco/notion-sync@8.0.0':
     dependencies:
       '@notionhq/client': 5.6.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -1,4 +1,4 @@
-import { syncNotionDatasource } from '@lacolaco/notion-sync';
+import { syncNotionDatasource, type PostMetadata } from '@lacolaco/notion-sync';
 import { parseArgs } from 'node:util';
 import { readdir, stat, rename, unlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -123,7 +123,7 @@ async function resizeOversizedImages() {
 }
 
 async function main() {
-  const result = await syncNotionDatasource({
+  const result = await syncNotionDatasource<PostMetadata & ZennMetadata>({
     notion: {
       token: NOTION_AUTH_TOKEN,
       datasourceId: DATASOURCE_ID,
@@ -202,13 +202,12 @@ async function main() {
       // Custom frontmatter generation for Zenn
       generateFrontmatter: (baseFields, metadata, renderContext) => {
         const { source_url, created_time } = baseFields;
-        const zennMetadata = metadata as typeof metadata & ZennMetadata;
 
-        const publishedAt = new Date(zennMetadata.createdAtOverride || created_time).toISOString();
+        const publishedAt = new Date(metadata.createdAtOverride || created_time).toISOString();
 
         // Merge 'angular' channel into topics for Zenn
         const tags: string[] = (baseFields.tags || []).map((tag: string) => tag.toLowerCase());
-        const angularChannel = zennMetadata.channels.find(
+        const angularChannel = metadata.channels.find(
           (ch) => ch.toLowerCase() === 'angular',
         );
         const topics = angularChannel
@@ -221,8 +220,8 @@ async function main() {
           topics,
           published: baseFields.published ?? false,
           source: source_url,
-          type: zennMetadata.type,
-          emoji: zennMetadata.icon,
+          type: metadata.type,
+          emoji: metadata.icon,
         };
       },
 

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -157,11 +157,8 @@ async function main() {
 
       // Extract channels (formerly categories)
       const channels: string[] =
-        'channels' in page.properties &&
-        page.properties.channels.type === 'multi_select'
-          ? page.properties.channels.multi_select.map(
-              (opt: { name: string }) => opt.name,
-            )
+        'channels' in page.properties && page.properties.channels.type === 'multi_select'
+          ? page.properties.channels.multi_select.map((opt: { name: string }) => opt.name)
           : [];
 
       return {
@@ -179,19 +176,11 @@ async function main() {
         filePath: resolve(rootDir, 'articles', `${metadata.slug}.md`),
       }),
       getImageOutput: (image, metadata) => {
-        const urlFilename =
-          image.url.split('?')[0].split('#')[0].split('/').pop() ?? '';
+        const urlFilename = image.url.split('?')[0].split('#')[0].split('/').pop() ?? '';
         const dotIndex = urlFilename.lastIndexOf('.');
-        const name =
-          dotIndex > 0 ? urlFilename.substring(0, dotIndex) : urlFilename;
-        const ext =
-          dotIndex > 0
-            ? urlFilename.substring(dotIndex + 1).toLowerCase()
-            : 'png';
-        const hash = createHash('sha256')
-          .update(image.blockId)
-          .digest('hex')
-          .substring(0, 16);
+        const name = dotIndex > 0 ? urlFilename.substring(0, dotIndex) : urlFilename;
+        const ext = dotIndex > 0 ? urlFilename.substring(dotIndex + 1).toLowerCase() : 'png';
+        const hash = createHash('sha256').update(image.blockId).digest('hex').substring(0, 16);
         const filename = `${name}.${hash}.${ext}`;
         return {
           src: `/images/${metadata.slug}/${filename}`,
@@ -207,12 +196,8 @@ async function main() {
 
         // Merge 'angular' channel into topics for Zenn
         const tags: string[] = (baseFields.tags || []).map((tag: string) => tag.toLowerCase());
-        const angularChannel = metadata.channels.find(
-          (ch) => ch.toLowerCase() === 'angular',
-        );
-        const topics = angularChannel
-          ? [angularChannel.toLowerCase(), ...tags]
-          : tags;
+        const angularChannel = metadata.channels.find((ch) => ch.toLowerCase() === 'angular');
+        const topics = angularChannel ? [angularChannel.toLowerCase(), ...tags] : tags;
 
         return {
           title: baseFields.title,


### PR DESCRIPTION
## Summary

- `@lacolaco/notion-sync` を v7 から v8 にアップグレード
- `syncNotionDatasource` にジェネリック型パラメータ `<PostMetadata & ZennMetadata>` を適用し、`generateFrontmatter` 内の unsafe な型キャストを除去
- v8 で削除されたデフォルトフィルタ (`filterPost`) は `queryFilter` で `published: true` を既に指定しているため影響なし
- notion-sync マイグレーション用スキルを追加

## Breaking Changes (v8)

| 変更 | 影響 |
|---|---|
| `filterPost` → `filter` | 未使用のため影響なし |
| デフォルトフィルタ `(m) => m.published` 削除 | `queryFilter` で対応済み |
| ジェネリック型パラメータ追加 | 適用済み |
