### PR TITLE
feat(notion-sync): migrate @lacolaco/notion-sync from v9 to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@lacolaco/notion-sync": "^9.0.0",
+    "@lacolaco/notion-sync": "^10.0.0",
     "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.18.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.34.4
     devDependencies:
       '@lacolaco/notion-sync':
-        specifier: ^9.0.0
-        version: 9.0.0
+        specifier: ^10.0.0
+        version: 10.0.0
       '@notionhq/client':
         specifier: 3.1.3
         version: 3.1.3
@@ -327,8 +327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lacolaco/notion-sync@9.0.0':
-    resolution: {integrity: sha512-KU0r1gIPRVHX79lHcxR+O+T5oZWI5xTw32jNQNdSiFW0zayD51Nwxbbq+AIWuLRVDE9UlzYuWrqqKQ6NnuLQJg==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/9.0.0/4793d89d9865de340255d03ebebec3682769f591}
+  '@lacolaco/notion-sync@10.0.0':
+    resolution: {integrity: sha512-VKwicb3wdDLGDw9QVAkL2wtug2NqvivaiTixsfo2tIS6NOI+k5L3JY37Xr7zRV7i3a2WRPyb3ZZUNLJHarBUIA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/10.0.0/6a81484450b167b5084c5f0b54507792f201c3bb}
 
   '@notionhq/client@3.1.3':
     resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
@@ -644,7 +644,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@lacolaco/notion-sync@9.0.0':
+  '@lacolaco/notion-sync@10.0.0':
     dependencies:
       '@notionhq/client': 5.6.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -1,4 +1,4 @@
-import { syncNotionDatasource, type PostMetadata } from '@lacolaco/notion-sync';
+import { syncNotionDatasource, extractProperty, type PostMetadata } from '@lacolaco/notion-sync';
 import { parseArgs } from 'node:util';
 import { readdir, stat, rename, unlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -12,11 +12,13 @@ dayjs.extend(utc);
 dayjs.extend(tz);
 
 // Custom metadata type for Zenn articles
-interface ZennMetadata {
+interface ZennMetadata extends PostMetadata {
   icon: string;
-  createdAtOverride: string | null;
   type: 'tech' | 'idea';
   channels: string[];
+  published: boolean;
+  tags: string[];
+  sourceUrl: string;
 }
 
 if (process.env.NOTION_AUTH_TOKEN == null) {
@@ -123,7 +125,7 @@ async function resizeOversizedImages() {
 }
 
 async function main() {
-  const result = await syncNotionDatasource<PostMetadata & ZennMetadata>({
+  const result = await syncNotionDatasource<ZennMetadata>({
     notion: {
       token: NOTION_AUTH_TOKEN,
       datasourceId: DATASOURCE_ID,
@@ -142,31 +144,18 @@ async function main() {
     dryRun,
 
     // Custom metadata extraction
-    extractMetadata: (page, defaultExtractor) => {
+    extractMetadata: (page, defaultExtractor): ZennMetadata => {
       const metadata = defaultExtractor(page);
       const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '✨';
-      const createdAtOverride =
-        'created_at_override' in page.properties &&
-        page.properties.created_at_override.type === 'date' &&
-        page.properties.created_at_override.date?.start
-          ? page.properties.created_at_override.date.start
-          : null;
-
-      // Type: default to 'tech' (Zenn requirement)
-      const type: 'tech' | 'idea' = 'tech';
-
-      // Extract channels (formerly categories)
-      const channels: string[] =
-        'channels' in page.properties && page.properties.channels.type === 'multi_select'
-          ? page.properties.channels.multi_select.map((opt: { name: string }) => opt.name)
-          : [];
 
       return {
         ...metadata,
         icon,
-        createdAtOverride,
-        type,
-        channels,
+        type: 'tech',
+        channels: extractProperty<string[]>(page, 'channels') ?? [],
+        published: Boolean(extractProperty<boolean>(page, 'published')),
+        tags: extractProperty<string[]>(page, 'tags') ?? [],
+        sourceUrl: page.url,
       };
     },
 
@@ -189,22 +178,18 @@ async function main() {
       },
 
       // Custom frontmatter generation for Zenn
-      generateFrontmatter: (baseFields, metadata, renderContext) => {
-        const { source_url, created_time } = baseFields;
-
-        const publishedAt = new Date(metadata.createdAtOverride || created_time).toISOString();
-
+      generateFrontmatter: (baseFields, metadata) => {
         // Merge 'angular' channel into topics for Zenn
-        const tags: string[] = (baseFields.tags || []).map((tag: string) => tag.toLowerCase());
+        const tags = metadata.tags.map((tag) => tag.toLowerCase());
         const angularChannel = metadata.channels.find((ch) => ch.toLowerCase() === 'angular');
         const topics = angularChannel ? [angularChannel.toLowerCase(), ...tags] : tags;
 
         return {
           title: baseFields.title,
-          published_at: dayjs(publishedAt).tz('Asia/Tokyo').format('YYYY-MM-DD HH:mm'),
+          published_at: dayjs(metadata.date).tz('Asia/Tokyo').format('YYYY-MM-DD HH:mm'),
           topics,
-          published: baseFields.published ?? false,
-          source: source_url,
+          published: metadata.published,
+          source: metadata.sourceUrl,
           type: metadata.type,
           emoji: metadata.icon,
         };

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -14,6 +14,7 @@ dayjs.extend(tz);
 // Custom metadata type for Zenn articles
 interface ZennMetadata extends PostMetadata {
   icon: string;
+  createdAtOverride: string | null;
   type: 'tech' | 'idea';
   channels: string[];
   published: boolean;
@@ -151,6 +152,7 @@ async function main() {
       return {
         ...metadata,
         icon,
+        createdAtOverride: extractProperty<string>(page, 'created_at_override') ?? null,
         type: 'tech',
         channels: extractProperty<string[]>(page, 'channels') ?? [],
         published: Boolean(extractProperty<boolean>(page, 'published')),
@@ -186,7 +188,9 @@ async function main() {
 
         return {
           title: baseFields.title,
-          published_at: dayjs(metadata.date).tz('Asia/Tokyo').format('YYYY-MM-DD HH:mm'),
+          published_at: dayjs(metadata.createdAtOverride ?? metadata.date)
+            .tz('Asia/Tokyo')
+            .format('YYYY-MM-DD HH:mm'),
           topics,
           published: metadata.published,
           source: metadata.sourceUrl,

--- a/tools/notion-sync/test.ts
+++ b/tools/notion-sync/test.ts
@@ -27,7 +27,10 @@ test('existing article has exact frontmatter schema', async () => {
   const lines = frontmatter.split('\n').filter((l) => l.trim() && !l.startsWith('  '));
   const allowedFields = ['title:', 'published_at:', 'topics:', 'published:', 'source:', 'type:', 'emoji:'];
   for (const line of lines) {
-    assert.ok(allowedFields.some((field) => line.startsWith(field)), `Unexpected frontmatter field: ${line}`);
+    assert.ok(
+      allowedFields.some((field) => line.startsWith(field)),
+      `Unexpected frontmatter field: ${line}`,
+    );
   }
 });
 
@@ -42,7 +45,10 @@ test('existing article uses correct image path format', async () => {
       const path3Tier = match.match(/\/images\/([^/]+)\/([^/]+)\/([^)]+)/);
       const path2Tier = match.match(/\/images\/([^/]+)\/([^)]+)/);
 
-      assert.ok(path3Tier || path2Tier, `Image path must be valid: /images/{slug}/{file} or /images/{slug}/{dir}/{file}. Got: ${match}`);
+      assert.ok(
+        path3Tier || path2Tier,
+        `Image path must be valid: /images/{slug}/{file} or /images/{slug}/{dir}/{file}. Got: ${match}`,
+      );
 
       if (path3Tier) {
         const [, slug, dir, file] = path3Tier;


### PR DESCRIPTION
## Summary

- `@lacolaco/notion-sync` を v9 から v10 にアップグレード
- v10で `PostMetadata` から削除された passthrough フィールド (`published`, `tags`, `source_url`, `created_time` 等) を `extractProperty()` による個別抽出に移行
- `ZennMetadata` を `PostMetadata` 拡張型として再定義し、型安全性を向上
- `generateFrontmatter` から未使用の `renderContext` 引数を削除

## Breaking Changes対応

| v9 (`baseFields.*`) | v10 (`metadata.*` / `extractProperty`) |
|---|---|
| `baseFields.published` | `extractProperty<boolean>(page, 'published')` → `metadata.published` |
| `baseFields.tags` | `extractProperty<string[]>(page, 'tags')` → `metadata.tags` |
| `baseFields.source_url` | `page.url` → `metadata.sourceUrl` |
| `baseFields.created_time` | `metadata.date` (PostMetadataの`date`フィールド) |

## Verification

- `npx tsc --noEmit -p tools/tsconfig.json` - pass
- `pnpm notion-sync --dry-run --verbose` - pass
- `pnpm format` - pass (no changes)
