### PR TITLE
feat(notion-sync): migrate @lacolaco/notion-sync from v10 to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@lacolaco/notion-sync": "^10.0.0",
+    "@lacolaco/notion-sync": "^11.0.0",
     "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.18.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.34.4
     devDependencies:
       '@lacolaco/notion-sync':
-        specifier: ^10.0.0
-        version: 10.0.0
+        specifier: ^11.0.0
+        version: 11.0.0
       '@notionhq/client':
         specifier: 3.1.3
         version: 3.1.3
@@ -327,8 +327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lacolaco/notion-sync@10.0.0':
-    resolution: {integrity: sha512-VKwicb3wdDLGDw9QVAkL2wtug2NqvivaiTixsfo2tIS6NOI+k5L3JY37Xr7zRV7i3a2WRPyb3ZZUNLJHarBUIA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/10.0.0/6a81484450b167b5084c5f0b54507792f201c3bb}
+  '@lacolaco/notion-sync@11.0.0':
+    resolution: {integrity: sha512-1GQ59EYNPly3ZdBHyZXrWVB2Pu5mjQjx5pp70vQ4HuKqmfMj1+6U8OAa18tAhUeC5LnUSyfwLmQcROv0ZlH0VA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/11.0.0/3ac0d0a3bfd5b0494e7ea55fc68013e8705c5153}
 
   '@notionhq/client@3.1.3':
     resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
@@ -644,7 +644,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@lacolaco/notion-sync@10.0.0':
+  '@lacolaco/notion-sync@11.0.0':
     dependencies:
       '@notionhq/client': 5.6.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -148,11 +148,13 @@ async function main() {
     extractMetadata: (page, defaultExtractor): ZennMetadata => {
       const metadata = defaultExtractor(page);
       const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '✨';
+      const createdAtOverride = extractProperty<string>(page, 'created_at_override') ?? null;
 
       return {
         ...metadata,
+        date: createdAtOverride ? new Date(createdAtOverride) : metadata.date,
         icon,
-        createdAtOverride: extractProperty<string>(page, 'created_at_override') ?? null,
+        createdAtOverride,
         type: 'tech',
         channels: extractProperty<string[]>(page, 'channels') ?? [],
         published: Boolean(extractProperty<boolean>(page, 'published')),


### PR DESCRIPTION
## Summary

- `@lacolaco/notion-sync` を v10 から v11 にアップグレード
- v11で `extractDate()` が `created_at_override` を参照しなくなったため、`extractMetadata` 内で `metadata.date` を明示的にオーバーライドするよう変更

## Breaking Changes対応

| Breaking Change | 影響 | 対応 |
|---|---|---|
| `DatasourcePageProperties` が `title`/`slug` のみに簡素化 | なし（既に `extractProperty()` で全プロパティアクセス済み） | 変更不要 |
| `extractDate()` が `created_at_override` を使用しなくなった | `metadata.date` が `page.created_time` のみになる | `extractMetadata` 内で `createdAtOverride` があれば `date` をオーバーライド |

## Verification

- `tsc --noEmit` pass
- `pnpm notion-sync --dry-run` pass
- `pnpm format` pass
