### PR TITLE
feat(notion-sync): migrate @lacolaco/notion-sync from v11 to v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@ node_modules
 .env
 .DS_Store
 .cache
-
-# notion-sync generated metadata
-articles/metadata.json

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@lacolaco/notion-sync": "^11.0.0",
+    "@lacolaco/notion-sync": "^12.0.0",
     "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.18.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.34.4
     devDependencies:
       '@lacolaco/notion-sync':
-        specifier: ^11.0.0
-        version: 11.0.0
+        specifier: ^12.0.0
+        version: 12.0.0
       '@notionhq/client':
         specifier: 3.1.3
         version: 3.1.3
@@ -327,8 +327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lacolaco/notion-sync@11.0.0':
-    resolution: {integrity: sha512-1GQ59EYNPly3ZdBHyZXrWVB2Pu5mjQjx5pp70vQ4HuKqmfMj1+6U8OAa18tAhUeC5LnUSyfwLmQcROv0ZlH0VA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/11.0.0/3ac0d0a3bfd5b0494e7ea55fc68013e8705c5153}
+  '@lacolaco/notion-sync@12.0.0':
+    resolution: {integrity: sha512-Iq67s0HfQwpKtnxrxJHiNLVOor2rRODHy5aVrVb+ET8ZUZMaY2gyqDtutPMzk8DjBDjvCApuH4qx/giAJlJm4w==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/12.0.0/dcfaee2ba685dd1acd7c1c4e52720f77bfd2eaf2}
 
   '@notionhq/client@3.1.3':
     resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
@@ -644,7 +644,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@lacolaco/notion-sync@11.0.0':
+  '@lacolaco/notion-sync@12.0.0':
     dependencies:
       '@notionhq/client': 5.6.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -1,4 +1,4 @@
-import { syncNotionDatasource, extractProperty, type PostMetadata } from '@lacolaco/notion-sync';
+import { syncNotionDatasource, extractProperty, type EntryMetadata } from '@lacolaco/notion-sync';
 import { parseArgs } from 'node:util';
 import { readdir, stat, rename, unlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -12,7 +12,7 @@ dayjs.extend(utc);
 dayjs.extend(tz);
 
 // Custom metadata type for Zenn articles
-interface ZennMetadata extends PostMetadata {
+interface ZennMetadata extends EntryMetadata {
   icon: string;
   createdAtOverride: string | null;
   type: 'tech' | 'idea';
@@ -138,7 +138,6 @@ async function main() {
       ],
     },
     manifestPath: `${rootDir}/notion-sync.manifest.json`,
-    metadataFilePath: resolve(rootDir, 'articles', 'metadata.json'),
     verbose,
     mode: mode as 'incremental' | 'all',
     force,


### PR DESCRIPTION
## Summary

- `PostMetadata` → `EntryMetadata` にリネーム（v12 Breaking Change）
- `metadataFilePath` オプションが削除されたため、設定を削除
- 書き出されなくなる `articles/metadata.json` と対応する `.gitignore` エントリを削除

## Test plan

- [x] `npx tsc --noEmit -p tools/tsconfig.json` pass
- [x] `pnpm notion-sync --dry-run` pass（queryFilterが正しく動作、metadata.json書き込み無し）
- [x] `pnpm format` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)