### PR TITLE
docs(notion-sync-migration): fix dry-run command

### DIFF
--- a/.claude/skills/notion-sync-migration/SKILL.md
+++ b/.claude/skills/notion-sync-migration/SKILL.md
@@ -85,11 +85,12 @@ Breaking Changesの一覧を列挙し、現在のコード（`tools/notion-sync/
 
 ```bash
 npx tsc --noEmit -p tools/tsconfig.json
-pnpm notion-sync -- --dry-run
+pnpm notion-sync --dry-run
 pnpm format
 ```
 
 dry-runの出力を確認し、queryFilterやmetadata生成が正しく動作していることを検証する。
+`--mode all` を付与した二重検証で `queryFilter` の動作（取得件数）を裏取りすると信頼度が上がる。
 
 ### 7. コミット・PR
 


### PR DESCRIPTION
## Summary

- `pnpm notion-sync -- --dry-run` の `--` は `parseArgs` で positional argument として扱われ `ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL` になる
- `pnpm notion-sync --dry-run` に修正
- `queryFilter` 動作確認用の `--mode all` ガイダンスを追記

## Test plan

- [x] 実環境で `pnpm notion-sync --dry-run` と `--mode all --dry-run` 動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)