### PR TITLE
feat(notion-sync): migrate @lacolaco/notion-sync from v12 to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@lacolaco/notion-sync": "^12.0.0",
+    "@lacolaco/notion-sync": "^13.0.0",
     "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.18.11",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^22.0.0"
   },
   "devDependencies": {
-    "@lacolaco/notion-sync": "^13.0.0",
+    "@lacolaco/notion-sync": "^14.0.0",
     "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.18.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.34.4
     devDependencies:
       '@lacolaco/notion-sync':
-        specifier: ^12.0.0
-        version: 12.0.0
+        specifier: ^13.0.0
+        version: 13.0.0
       '@notionhq/client':
         specifier: 3.1.3
         version: 3.1.3
@@ -327,8 +327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lacolaco/notion-sync@12.0.0':
-    resolution: {integrity: sha512-Iq67s0HfQwpKtnxrxJHiNLVOor2rRODHy5aVrVb+ET8ZUZMaY2gyqDtutPMzk8DjBDjvCApuH4qx/giAJlJm4w==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/12.0.0/dcfaee2ba685dd1acd7c1c4e52720f77bfd2eaf2}
+  '@lacolaco/notion-sync@13.0.0':
+    resolution: {integrity: sha512-vI0isLcPFPtxLeKzjfZiCaMPaKHKAStACPbuJ6gWjhUBuDvPVWK5nuZmR5tJNx3vPrJxkkofnb7ndSe45F85/Q==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/13.0.0/517bf8461b1bc77f714f1ca1c19319a93d149655}
 
   '@notionhq/client@3.1.3':
     resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
@@ -685,7 +685,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@lacolaco/notion-sync@12.0.0':
+  '@lacolaco/notion-sync@13.0.0':
     dependencies:
       '@notionhq/client': 5.6.0
       cli-progress: 3.12.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.34.4
     devDependencies:
       '@lacolaco/notion-sync':
-        specifier: ^13.0.0
-        version: 13.0.0
+        specifier: ^14.0.0
+        version: 14.0.0
       '@notionhq/client':
         specifier: 3.1.3
         version: 3.1.3
@@ -327,8 +327,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@lacolaco/notion-sync@13.0.0':
-    resolution: {integrity: sha512-vI0isLcPFPtxLeKzjfZiCaMPaKHKAStACPbuJ6gWjhUBuDvPVWK5nuZmR5tJNx3vPrJxkkofnb7ndSe45F85/Q==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/13.0.0/517bf8461b1bc77f714f1ca1c19319a93d149655}
+  '@lacolaco/notion-sync@14.0.0':
+    resolution: {integrity: sha512-cWxO1L11J2keEv0kBLODlmW4rTYrfyJ2E0GNQFCBAtLUOB+KwYXyivclqr9nTiFJKtzAlEvHqCbrT3/7W9QilA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/14.0.0/41ea83f282284ac221e009e1eefafe3ed255a4fc}
 
   '@notionhq/client@3.1.3':
     resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
@@ -685,7 +685,7 @@ snapshots:
   '@img/sharp-win32-x64@0.34.4':
     optional: true
 
-  '@lacolaco/notion-sync@13.0.0':
+  '@lacolaco/notion-sync@14.0.0':
     dependencies:
       '@notionhq/client': 5.6.0
       cli-progress: 3.12.0

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -1,7 +1,7 @@
 import { syncNotionDatasource, type EntryMetadata } from '@lacolaco/notion-sync';
 import { parseArgs } from 'node:util';
 import { readdir, stat, rename, unlink } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import sharp from 'sharp';
 import dayjs from 'dayjs';
@@ -147,7 +147,8 @@ async function main() {
         { property: 'published', checkbox: { equals: true } },
       ],
     },
-    manifestPath: `${rootDir}/notion-sync.manifest.json`,
+    cwd: rootDir,
+    manifestPath: 'notion-sync.manifest.json',
     verbose,
     mode: mode as 'incremental' | 'all',
     force,
@@ -175,7 +176,7 @@ async function main() {
     // Markdown rendering options
     renderMarkdown: {
       getPageOutput: (metadata) => ({
-        filePath: resolve(rootDir, 'articles', `${metadata.slug}.md`),
+        filePath: join('articles', `${metadata.slug}.md`),
       }),
       getImageOutput: (image, metadata) => {
         const urlFilename = image.url.split('?')[0].split('#')[0].split('/').pop() ?? '';
@@ -186,7 +187,7 @@ async function main() {
         const filename = `${name}.${hash}.${ext}`;
         return {
           src: `/images/${metadata.slug}/${filename}`,
-          filePath: resolve(rootDir, 'images', metadata.slug, filename),
+          filePath: join('images', metadata.slug, filename),
         };
       },
 

--- a/tools/notion-sync/main.ts
+++ b/tools/notion-sync/main.ts
@@ -1,4 +1,4 @@
-import { syncNotionDatasource, extractProperty, type EntryMetadata } from '@lacolaco/notion-sync';
+import { syncNotionDatasource, type EntryMetadata } from '@lacolaco/notion-sync';
 import { parseArgs } from 'node:util';
 import { readdir, stat, rename, unlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
@@ -11,8 +11,8 @@ import tz from 'dayjs/plugin/timezone.js';
 dayjs.extend(utc);
 dayjs.extend(tz);
 
-// Custom metadata type for Zenn articles
 interface ZennMetadata extends EntryMetadata {
+  slug: string;
   icon: string;
   createdAtOverride: string | null;
   type: 'tech' | 'idea';
@@ -21,6 +21,16 @@ interface ZennMetadata extends EntryMetadata {
   tags: string[];
   sourceUrl: string;
 }
+
+type ZennDatasource = {
+  title: string;
+  date: Date;
+  slug: string | undefined;
+  created_at_override: string | undefined;
+  channels: string[] | undefined;
+  published: boolean;
+  tags: string[] | undefined;
+};
 
 if (process.env.NOTION_AUTH_TOKEN == null) {
   console.error('Please set NOTION_AUTH_TOKEN');
@@ -126,7 +136,7 @@ async function resizeOversizedImages() {
 }
 
 async function main() {
-  const result = await syncNotionDatasource<ZennMetadata>({
+  const result = await syncNotionDatasource<ZennMetadata, ZennDatasource>({
     notion: {
       token: NOTION_AUTH_TOKEN,
       datasourceId: DATASOURCE_ID,
@@ -143,21 +153,21 @@ async function main() {
     force,
     dryRun,
 
-    // Custom metadata extraction
-    extractMetadata: (page, defaultExtractor): ZennMetadata => {
-      const metadata = defaultExtractor(page);
+    extractMetadata: (page, get): ZennMetadata => {
       const icon = page.icon && page.icon.type === 'emoji' ? page.icon.emoji : '✨';
-      const createdAtOverride = extractProperty<string>(page, 'created_at_override') ?? null;
+      const createdAtOverride = get('created_at_override') ?? null;
+      const date = get('date');
 
       return {
-        ...metadata,
-        date: createdAtOverride ? new Date(createdAtOverride) : metadata.date,
+        title: get('title'),
+        date: createdAtOverride ? new Date(createdAtOverride) : date,
+        slug: get('slug') ?? page.id,
         icon,
         createdAtOverride,
         type: 'tech',
-        channels: extractProperty<string[]>(page, 'channels') ?? [],
-        published: Boolean(extractProperty<boolean>(page, 'published')),
-        tags: extractProperty<string[]>(page, 'tags') ?? [],
+        channels: get('channels') ?? [],
+        published: Boolean(get('published')),
+        tags: get('tags') ?? [],
         sourceUrl: page.url,
       };
     },


### PR DESCRIPTION
## Summary

`@lacolaco/notion-sync` を v12 → v14 に直接更新（v13 はスキップ）。あわせて manifest を環境非依存にする。

### Breaking changes

#### v13.0.0
- `slug` が `EntryMetadata` から削除され、Notion ページの `slug` プロパティも必須ではなくなった。消費者側で `EntryMetadata` を拡張し、`extractMetadata` で `slug` を抽出する必要がある。
- `extractProperty` が公開 API から削除された。すべてのプロパティは `extractMetadata` に注入される型付き `get` アクセサ経由で取得する。
- `extractMetadata` のシグネチャが `(page, defaultExtractor) => TMetadata` から `(page, get) => TMetadata` に変更。
- `syncNotionDatasource` が第 2 型パラメータ `TSchema`（Notion DB のプロパティ型）を受け取るようになった。
- Manifest スキーマ変更: per-page `slug` が削除され、optional `imagePaths: string[]` が追加された。

#### v14.0.0
- `process.cwd()` フォールバック削除。`manifestPath` 省略時、または `getPageOutput`/`getImageOutput`/`propertyOutputs` が相対パスを返す場合、`config.cwd` の明示設定が必須。

### Fix: 環境依存 manifest の解消

これまでの `manifest.filePath` は絶対パス（`/Users/lacolaco/works/zenn/articles/...`）で記録されており、CI や別マシンで repo を clone した場合に manifest が無効になる環境依存問題があった。v14 推奨パターンを採用してこれを修正:

- `cwd: rootDir`（ワークスペースルート）を明示
- `manifestPath`/`getPageOutput`/`getImageOutput` を相対パスに変更
- 結果として manifest 内の `filePath` も相対パスで記録されるようになり、環境非依存になる

### 変更内容

- `ZennMetadata` に `slug: string` を追加。
- `ZennDatasource` 型を新規定義（Notion DB のプロパティ型を記述）。
- `syncNotionDatasource<ZennMetadata, ZennDatasource>` で TSchema を明示。
- `extractMetadata` を新シグネチャに書き換え、`extractProperty` → `get` へ置換。
- `cwd: rootDir` を追加し、`getPageOutput`/`getImageOutput`/`manifestPath` を相対パスに変更（`resolve` → `join`）。
- 既存の消費者側抽出（`createdAtOverride` 明示取得、`published` の `Boolean` ラップ等）は保持。

### Post-merge action

マニフェストを v14 スキーマかつ相対パスで書き直すため、マージ後に一度 `pnpm notion-sync --mode all` を実行する。

## Test plan

- [x] `npx tsc --noEmit -p tools/tsconfig.json` 通過
- [x] `pnpm notion-sync --dry-run` 成功（incremental, manifest path のダブルスラッシュ問題が解消）
- [x] `pnpm notion-sync --mode all --dry-run` 成功（all: 40 件取得、queryFilter の動作を裏取り）
- [x] `pnpm format` 通過
