### PR TITLE
chore(deps): remove unused @notionhq/client dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "@lacolaco/notion-sync": "^14.0.0",
-    "@notionhq/client": "3.1.3",
     "@types/js-yaml": "4.0.9",
     "@types/node": "22.19.17",
     "dayjs": "^1.11.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ importers:
       '@lacolaco/notion-sync':
         specifier: ^14.0.0
         version: 14.0.0
-      '@notionhq/client':
-        specifier: 3.1.3
-        version: 3.1.3
       '@types/js-yaml':
         specifier: 4.0.9
         version: 4.0.9
@@ -255,6 +252,7 @@ packages:
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
@@ -306,6 +304,7 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
@@ -360,10 +359,6 @@ packages:
 
   '@lacolaco/notion-sync@14.0.0':
     resolution: {integrity: sha512-cWxO1L11J2keEv0kBLODlmW4rTYrfyJ2E0GNQFCBAtLUOB+KwYXyivclqr9nTiFJKtzAlEvHqCbrT3/7W9QilA==, tarball: https://npm.pkg.github.com/download/@lacolaco/notion-sync/14.0.0/41ea83f282284ac221e009e1eefafe3ed255a4fc}
-
-  '@notionhq/client@3.1.3':
-    resolution: {integrity: sha512-M2gVWoo1dIvBeX/Yc4fvQCVh2g3HQjOxKBWX472Qzma2VNMJV3cPLi0J0A4dmOlkcfNQLVXmhuh54zGHpptZ7g==}
-    engines: {node: '>=18'}
 
   '@notionhq/client@5.6.0':
     resolution: {integrity: sha512-eA3dO87vQJhFmR59utXH8r0nnulW7C7oTcxfp3bpiiTiv59luCkOkbbALCIa8TzBDdELoRD/zJEIfKcynyFR6Q==}
@@ -738,8 +733,6 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.0.0
       zod: 4.2.1
-
-  '@notionhq/client@3.1.3': {}
 
   '@notionhq/client@5.6.0': {}
 


### PR DESCRIPTION
tools/ 下で @notionhq/client を直接 import している箇所がなく、推移的依存 (@lacolaco/notion-sync 経由) のみなので、直接依存を削除した。Renovate PR #209 はクローズ済み。\n\n- `npx tsc --noEmit` 通過\n- `pnpm notion-sync --dry-run` 成功