### PR TITLE
fix(ci): SHA-pin actions and fix re-actors/alls-green ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: touch .env
-      - run: pnpm notion-sync -- --dry-run
+      - run: pnpm notion-sync --dry-run
         env:
           NOTION_AUTH_TOKEN: ${{ secrets.NOTION_AUTH_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,7 @@ jobs:
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: re-actors/alls-green@v1
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           allowed-skips: renovate-review, content-review, code-review
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       content_changed: ${{ !github.event.pull_request.draft && steps.content-paths.outputs.content == 'true' }}
       has_non_renovate_commits: ${{ steps.non-renovate-commits.outputs.has_non_renovate_commits == 'true' }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: content-paths
         with:
           filters: |
@@ -48,7 +48,7 @@ jobs:
               - 'images/**'
               - 'notion-sync.manifest.json'
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: code-paths
         with:
           predicate-quantifier: 'every'
@@ -91,9 +91,9 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
           cache: pnpm
@@ -107,9 +107,9 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
           cache: pnpm
@@ -123,9 +123,9 @@ jobs:
   notion-sync-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
           cache: pnpm
@@ -135,7 +135,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: touch .env
-      - run: pnpm notion-sync --dry-run
+      - run: pnpm notion-sync -- --dry-run
         env:
           NOTION_AUTH_TOKEN: ${{ secrets.NOTION_AUTH_TOKEN }}
 
@@ -153,9 +153,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: koki-develop/claude-renovate-review@v1
+      - uses: koki-develop/claude-renovate-review@e7cbeb9c2112243379890c197f64620623bd3460 # v1.3.0
         id: review
         with:
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -195,13 +195,13 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Review content with Claude
         id: review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1.0.104
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'lacolaco-actions-worker[bot]'
@@ -285,13 +285,13 @@ jobs:
       issues: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Review code with Claude
         id: review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@b4d67413279fc18c6e5de930ae307c4f108714eb # v1.0.104
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'lacolaco-actions-worker[bot]'
@@ -385,7 +385,7 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.WORKER_APP_ID }}
           private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
PR #245 で導入した ci.yml のレビューにあたり、blog.lacolaco.net の前例から私が独自判断で変えた部分を修正する。

## 修正内容

1. **action 参照を全て SHA pin に統一** （blog の pinning 規約と揃える）
   - `actions/checkout@v6` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`
   - `pnpm/action-setup@v6` → `@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3`
   - `actions/setup-node@v6` → `@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0`
   - `dorny/paths-filter@v3` → `@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1`
   - `koki-develop/claude-renovate-review@v1` → `@e7cbeb9c2112243379890c197f64620623bd3460 # v1.3.0`
   - `anthropics/claude-code-action@v1` → `@b4d67413279fc18c6e5de930ae307c4f108714eb # v1.0.104`
   - `actions/create-github-app-token@v3` → `@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1`
   - `re-actors/alls-green@v1`（**存在しないタグでCI壊れていた**）→ `@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2`

2. **`pnpm notion-sync --dry-run` → `pnpm notion-sync -- --dry-run`** (blog の pnpm スクリプト引数渡し慣例に揃える)

## 影響

PR #247（自動 sync PR）が `unable to resolve action 'v1'` で ok ジョブが落ちていた直接原因を解消。マージ後、再 sync で動作確認できる。