### PR TITLE
chore: redirect /sync comment trigger to blog-contents

### DIFF
--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -8,31 +8,37 @@ jobs:
   trigger-sync:
     runs-on: ubuntu-latest
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/sync' }}
+    permissions:
+      issues: write # add reaction to comment
     steps:
-      - uses: xt0rted/pull-request-comment-branch@v3
-        id: comment-branch
       - name: Add reaction
-        if: ${{ success() && steps.comment-branch.outputs.head_ref == 'sync-with-notion' }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
-              content: 'eyes'
-            })
-      - name: Trigger Workflow
-        if: ${{ success() }}
-        uses: actions/github-script@v9
+              content: 'eyes',
+            });
+
+      # blog-contents への repository_dispatch には GITHUB_TOKEN だと権限不足のため App token を発行
+      - name: Generate App token (for blog-contents dispatch)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: lacolaco
+          repositories: blog-contents
+
+      - name: Dispatch sync workflow in blog-contents
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'sync-with-notion.yml',
-              ref: 'main',
-              inputs: {
-                forceUpdate: 'false'
-              }
-            })
+            await github.rest.repos.createDispatchEvent({
+              owner: 'lacolaco',
+              repo: 'blog-contents',
+              event_type: 'notion-sync-zenn',
+            });


### PR DESCRIPTION
## Summary

[lacolaco/blog-contents docs/plans/009-extract-public-consumer-syncs.md](https://github.com/lacolaco/blog-contents/blob/main/docs/plans/009-extract-public-consumer-syncs.md) **Phase 3B PR-z2**。

PR #294 で `sync-with-notion.yml` を削除済のため、`/sync` PR コメント trigger の dispatch 先を **blog-contents の `sync-zenn.yml`** に切替 (`repository_dispatch`, event_type: `notion-sync-zenn`)。

## 変更内容

- 旧: `xt0rted/pull-request-comment-branch` で head_ref 取得 + `github.rest.actions.createWorkflowDispatch` で同 repo `sync-with-notion.yml` を起動
- 新: App token (`WORKER_APP`, `repositories: blog-contents`) を発行して `github.rest.repos.createDispatchEvent` で blog-contents に dispatch
- `xt0rted/pull-request-comment-branch` action 依存削除 (head_ref check 不要)
- `permissions: issues: write` のみ (reaction 付与用)

## 挙動 (merge 後)

- consumer PR で `/sync` コメント → consumer が blog-contents へ `repository_dispatch (notion-sync-zenn)`
- blog-contents 側 `sync-zenn.yml` が起動
- blog-contents が zenn に cross-repo PR 作成

## Test plan

- [ ] CI: classify pass、ok pass (workflow 変更による code-review fail は documented exception で手動マージ)