### PR TITLE
chore: drop @lacolaco scope registry config (GitHub Packages no longer needed)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
   "postUpdateOptions": ["pnpmDedupe"],
   "minimumReleaseAge": "5 days",
   "prConcurrentLimit": 3,
-  "npmrc": "@lacolaco:registry=https://npm.pkg.github.com/",
   "packageRules": [
     {
       "groupName": "types packages",

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 shamefully-hoist=true
-@lacolaco:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Summary

[lacolaco/blog-contents docs/plans/009-extract-public-consumer-syncs.md](https://github.com/lacolaco/blog-contents/blob/main/docs/plans/009-extract-public-consumer-syncs.md) **Phase 3B PR-z3 (最終)**。

PR #294 で `@lacolaco/notion-sync` 削除済 + PR #296 で trigger workflow 切替済。**zenn から `@lacolaco` scope を使う package が全廃された**ため、registry config を cleanup する。

これにより consumer は GitHub Packages 認証無しで `pnpm install` が完了でき、**CCW (Claude Code for Web) で zenn を開いた時に install が 0 exit する状態になる** (plan 009 zenn track 最終目的達成)。

## 変更内容

- `.npmrc`: `@lacolaco:registry=https://npm.pkg.github.com` 行削除

`ci.yml` の setup-node 関連 cleanup は不要 (PR-z1 で format-check / typecheck / notion-sync-dry-run job が全削除されたため、setup-node を使う job 自体が zenn ci.yml に存在しない)。

## 全 PR 進行状況

1. ✅ PR #294 (notion-sync 削除)
2. ✅ PR #296 (/sync trigger を blog-contents へ redirect)
3. **PR #297 (本 PR) — @lacolaco scope cleanup**

## Test plan

- [ ] CI: classify pass、ok pass
- [ ] (merge 後) CCW で `lacolaco/zenn` を開いて `pnpm install` が 0 exit