### PR TITLE
ci(trigger): dispatch blog-contents sync on main push

### DIFF
--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -9,13 +9,10 @@ on:
   push:
     branches: [main]
 
-# 連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調
-concurrency:
-  group: dispatch-blog-contents-sync
-  cancel-in-progress: true
-
 jobs:
   comment-trigger:
+    # comment-trigger は concurrency 無し (ユーザー操作で reaction 付与済の comment-trigger を
+    # 後続 push で cancel すると 「eyes 付いたが dispatch されない」状態が発生するため)
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
@@ -57,6 +54,11 @@ jobs:
             });
 
   push-trigger:
+    # 連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調。
+    # comment-trigger には影響しないよう job レベルで設定
+    concurrency:
+      group: dispatch-blog-contents-sync-push
+      cancel-in-progress: true
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     # GITHUB_TOKEN は使わない (App token で dispatch)

--- a/.github/workflows/trigger-sync-from-pr-comment.yml
+++ b/.github/workflows/trigger-sync-from-pr-comment.yml
@@ -3,11 +3,24 @@ name: trigger-sync-from-pr-comment
 on:
   issue_comment:
     types: [created]
+  # consumer main 更新時に blog-contents の sync workflow を再走させ、
+  # 既存 sync PR (notion-sync-from-blog-contents branch) を最新 main base に rebase させる。
+  # 例: renovate PR merge / 人手 PR merge / sync PR merge → main が動く → 既存 sync PR が outdated
+  push:
+    branches: [main]
+
+# 連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調
+concurrency:
+  group: dispatch-blog-contents-sync
+  cancel-in-progress: true
 
 jobs:
-  trigger-sync:
+  comment-trigger:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/sync'
     runs-on: ubuntu-latest
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/sync' }}
     permissions:
       issues: write # add reaction to comment
     steps:
@@ -22,6 +35,34 @@ jobs:
               content: 'eyes',
             });
 
+      # blog-contents への repository_dispatch には GITHUB_TOKEN だと権限不足のため App token を発行
+      - name: Generate App token (for blog-contents dispatch)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.WORKER_APP_ID }}
+          private-key: ${{ secrets.WORKER_APP_PRIVATE_KEY }}
+          owner: lacolaco
+          repositories: blog-contents
+
+      - name: Dispatch sync workflow in blog-contents
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'lacolaco',
+              repo: 'blog-contents',
+              event_type: 'notion-sync-zenn',
+            });
+
+  push-trigger:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    # GITHUB_TOKEN は使わない (App token で dispatch)
+    permissions:
+      contents: read
+    steps:
       # blog-contents への repository_dispatch には GITHUB_TOKEN だと権限不足のため App token を発行
       - name: Generate App token (for blog-contents dispatch)
         id: app-token


### PR DESCRIPTION
## Summary

consumer main 更新時 (renovate PR merge / 人手 PR merge / sync PR merge) に blog-contents の sync workflow を再走させ、既存の sync PR (`notion-sync-from-blog-contents` branch) が outdated になる Gap を塞ぐ。

plan 009 Phase 4 検証で発覚した Gap 1 対応。blog-contents 側 `sync-zenn.yml` にも対称な push trigger を追加済 (lacolaco/blog-contents#391)。

## Changes

- `on.push.branches: [main]` を追加
- job を `comment-trigger` / `push-trigger` に分離 (event_name で if 分岐)
- workflow-level `concurrency` で連打 / 複数 main push を debounce、blog-contents 側 sync workflow の concurrency と協調
- `push-trigger` は GITHUB_TOKEN を使わず App token のみで dispatch (`permissions: contents: read`)

## Behavior

| Trigger | Action |
|---------|--------|
| `/sync` PR comment | (従来通り) reaction + dispatch |
| main push | dispatch のみ (連打は concurrency で 1 つに集約) |

dispatch event は両経路とも `repository_dispatch (notion-sync-zenn)` で同一。blog-contents 側 sync workflow が再走、peter-evans-create-pull-request が latest main base で sync PR branch を force-push、PR が rebased state に戻る。

## Test plan

- [ ] CI pass (workflow syntax validation)
- [ ] Merge 後、人手で main に dummy commit を push → trigger-sync-from-pr-comment が起動 → blog-contents で sync-zenn workflow が dispatch される
- [ ] 既存 `/sync` PR comment 経路は退行なく動作

## Notes

consumer 側 workflow ファイル変更 PR は claude-code-action の App token exchange が GitHub security 制約で fail するため、人間がレビューして手動マージする運用 (consumer `ci.yml` の comment に documented)。