### PR TITLE
chore: remove orphan prettier configs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,0 @@
-*.md
-notion-sync.manifest.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-  "singleQuote": true,
-  "trailingComma": "all",
-  "printWidth": 120
-}


### PR DESCRIPTION
## Summary

Phase 3B (notion-sync migration to blog-contents) で `prettier` パッケージは PR-z1 群で削除済だが、その設定ファイルだけ取り残されていたので削除する。

## 削除内容

- `.prettierrc.json` — prettier 未インストール状態で参照されないため
- `.prettierignore` — 同上

## 検証

- `package.json` 現状: `devDependencies` は `zenn-cli` のみ、`scripts` は `start: zenn` のみ → prettier 関連は完全に消えている
- CI workflow (`.github/workflows/ci.yml`) には format-check / typecheck job が無く、prettier を invoke する経路は無い
- `gh api search/code` で `prettier` 参照は当該 2 ファイルと CLAUDE.md の stale な記述のみ

## 本 PR の scope 外 (別途報告済)

`CLAUDE.md` には削除済 tool (`tools/notion-sync`, `pnpm format`, `pnpm notion-sync`, prettier 設定) の説明が大量に残っている。本 PR は deps cleanup に scope を限定するため触らない。別 PR / issue で対応する。

## Test plan

- [ ] CI green
- [ ] `pnpm install --frozen-lockfile` が依然成功すること (lockfile 変更なし)
- [ ] `pnpm start` (zenn preview) が動作すること