### PR TITLE
chore: add blog-content.config.yaml for blog-contents sync

### DIFF
--- a/blog-content.config.yaml
+++ b/blog-content.config.yaml
@@ -1,0 +1,5 @@
+# blog-contents の sync がこのリポジトリへ出力する際のファイル配置。
+# blog-contents 側コードではなくこのリポジトリが配置を所有する。
+postsDir: articles
+imagesDir: images
+manifestPath: notion-sync.manifest.json


### PR DESCRIPTION
## 背景

`blog-contents`（private）が Notion sync を集約して各 consumer に cross-repo PR で配信する構成（blog-contents の plan 009）で、**このリポジトリのファイル配置構造が blog-contents 側コードにハードコード**されていた。配置はこのリポジトリの関心事なので、所有権をこちらへ移す。

## 内容

repo root に `blog-content.config.yaml`（宣言的データ）を追加。blog-contents の sync がこのファイルを読んで出力先を決める。**値は現行 sync の出力先と完全に同一**（articles・images・notion-sync.manifest.json）。

純データファイルであり、このリポジトリの依存・ビルド・publish には影響しない（`@lacolaco/notion-sync` 依存は再導入されない）。

## マージ順序

このPRは **blog-contents 側の cut-over PR より先にマージ**する必要がある（blog-contents の loader は config 必須・fallback なし）。マージしても cut-over までは何も参照されない inert な状態。

- 関連: blog-contents PR #393（schema/loader）, #394（cut-over, draft）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
